### PR TITLE
Handle being able to re run deploy if error

### DIFF
--- a/app/views/layouts/_menu_item.html.haml
+++ b/app/views/layouts/_menu_item.html.haml
@@ -1,7 +1,7 @@
 %li.menu-item
   %div.menu-element
     = link_to(caption, target, class: 'main-collapsed-single js-select-current-parent js-feature-flag')
-  - if (can(target) && !@deploy_failed) || (target.include?('wrapup') && @deploy_failed) && !@refresh_timer
+  - if ((can(target) && !@deploy_failed) || (target.include?('wrapup') && @deploy_failed)) && !@refresh_timer
     = active_link_to(target, class: 'menu-title js-select-current-parent js-feature-flag') do
       %i.eos-icons-outlined= icon
       %span.menu-title-content= caption

--- a/engines/rancher_on_eks/app/controllers/rancher_on_eks/steps_controller.rb
+++ b/engines/rancher_on_eks/app/controllers/rancher_on_eks/steps_controller.rb
@@ -7,8 +7,7 @@ module RancherOnEks
       @complete = Step.all_complete?
       @resources = Resource.all
       redirect_to rancher_on_eks.wrapup_path if @complete
-
-      if Rails.application.config.lasso_error != ""
+      if Rails.application.config.lasso_error != "" && Rails.application.config.lasso_error != "error-cleanup"
         flash.now[:danger] = Rails.application.config.lasso_error
         @deploy_failed = true
         @complete = true

--- a/engines/rancher_on_eks/app/controllers/rancher_on_eks/wrapup_controller.rb
+++ b/engines/rancher_on_eks/app/controllers/rancher_on_eks/wrapup_controller.rb
@@ -13,7 +13,6 @@ module RancherOnEks
       @resources = Resource.all
       # keep showing the buttons after cleaning up
       @resources_created = @resources.length > 0 || params[:deleting]
-      @resources_deleted = Step.all_deleted?
       @downloading = ["running"].include? Rails.application.config.lasso_commands
       @refresh_timer = 15 if @in_process || @downloading
       if @lasso_commands && File.exist?(Rails.application.config.lasso_commands_file)

--- a/engines/rancher_on_eks/app/jobs/rancher_on_eks/wrapup_job.rb
+++ b/engines/rancher_on_eks/app/jobs/rancher_on_eks/wrapup_job.rb
@@ -4,6 +4,7 @@ module RancherOnEks
 
     after_perform do |job|
       Rails.application.config.lasso_commands = "done" if Rails.application.config.lasso_run != "true"
+      Rails.application.config.lasso_error = "error-cleanup" if Rails.application.config.lasso_error != "" # special value in case there were errors
     end
 
     def perform(*args)

--- a/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
+++ b/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
@@ -117,7 +117,7 @@ module RancherOnEks
     end
 
     def step(rank, force: false)
-      raise StandardError.new("Creating #{friendly_type(@type)}: status failed") if Rails.application.config.lasso_error.present?
+      raise StandardError.new("Creating #{ApplicationController.helpers.friendly_type(@type)}: status failed") if Rails.application.config.lasso_error.present? && Rails.application.config.lasso_error != "error-cleanup"
 
       step = Step.find_by(rank: rank)
       return if step.complete? && !force
@@ -304,7 +304,7 @@ module RancherOnEks
         @rancher.wait_until(:deployed)
       end
       # in case Rancher create command gets failed status
-      raise StandardError.new("Creating #{@type}: status failed") if Rails.application.config.lasso_error.present?
+      raise StandardError.new("Creating #{ApplicationController.helpers.friendly_type(@type)}: status failed") if Rails.application.config.lasso_error.present? && Rails.application.config.lasso_error != "error-cleanup"
     end
 
     def self.rollback


### PR DESCRIPTION
- Side menu not available during deployment
- Side menu not available during cleanup
- Remove errors after cleanup so rerun is possible
- Error wording in wrapup consistent