### PR TITLE
Use ID to destroy Rancher resource

### DIFF
--- a/engines/rancher_on_eks/app/models/rancher_on_eks/rancher.rb
+++ b/engines/rancher_on_eks/app/models/rancher_on_eks/rancher.rb
@@ -43,7 +43,7 @@ module RancherOnEks
     end
 
     def helm_destroy
-      @helm.delete_deployment(@release_name, NAMESPACE)
+      @helm.delete_deployment(self.id, NAMESPACE)
       throw(:abort) unless Rails.application.config.lasso_run.present?
 
       # @kubectl.delete_namespace(NAMESPACE) # This never completes :(


### PR DESCRIPTION
With custom fields, `release name` can be different, and `@release_name` does not work
raising an error for the command `helm uninstall '' --namespace cattle-system` with `Error: uninstall: Release name is invalid: .` 