### PR TITLE
Auto-generate production mode session secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ dist: clean
 	@sed -i '/source .*rubygems\.org/d' $(NAME)-$(VERSION)/Gemfile
 	@sed -i '/remote: .*rubygems\.org/d' $(NAME)-$(VERSION)/Gemfile.lock
 
+	# generate session secret
+	@cd $(NAME)-$(VERSION) && EDITOR=cat rails credentials:edit
+
 	# prebuild the database
 	@cd $(NAME)-$(VERSION) && RAILS_ENV=production rails db:reset
 


### PR DESCRIPTION
Since we'll never need access to the session/cookies, instead of maintaining a persistent production mode session secret, let's just generate one when when we package (we need it for the production mode asset pipeline).