### PR TITLE
Generate self-signed TLS cert in packaging

### DIFF
--- a/packaging/suse-rancher-setup.spec
+++ b/packaging/suse-rancher-setup.spec
@@ -33,6 +33,7 @@ BuildRequires:  %{ruby_version}-devel
 BuildRequires:  chrpath
 BuildRequires:  gcc
 BuildRequires:  nginx
+BuildRequires:  openssl
 BuildRequires:  sqlite3-devel
 Requires:       %{ruby_version}
 Requires:       kuberlr
@@ -125,6 +126,9 @@ rm -rf %{buildroot}%{app_dir}/server-configs
 
 # drop custom rpath from native gems
 chrpath -d %{buildroot}%{lib_dir}/vendor/bundle/ruby/*/gems/nokogiri-*/lib/nokogiri/*/nokogiri.so
+
+# generate TLS self-signed cert for nginx
+cd %{buildroot}%{app_dir}/public/ && openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/CN=localhost" -keyout suse-rancher-setup.key -out suse-rancher-setup.crt
 
 %files
 %attr(-,root,root) %{app_dir}

--- a/server-configs/nginx/suse-rancher-setup.conf
+++ b/server-configs/nginx/suse-rancher-setup.conf
@@ -10,8 +10,8 @@ server {
 
     root /usr/share/suse-rancher-setup/public;
 
-    ssl_certificate /usr/share/suse-rancher-setup/public/localhost.crt;
-    ssl_certificate_key /usr/share/suse-rancher-setup/public/localhost.key;
+    ssl_certificate /usr/share/suse-rancher-setup/public/suse-rancher-setup.crt;
+    ssl_certificate_key /usr/share/suse-rancher-setup/public/suse-rancher-setup.key;
 
     try_files $uri/index.html $uri @app;
     autoindex off;


### PR DESCRIPTION
Instead of keeping around a self-signed TLS cert that we have to inject into the package, let's generate one at packaging.

Bonus: cert isn't named 'localhost' anymore.