### PR TITLE
Load workflow & rancher source from an exteral config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@
 
 # Ignore certs and keys
 public/localhost.*
+
+# Ignore instance-specific config
+/config/config.yml

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ dist: clean
 	@cp -r README.md $(NAME)-$(VERSION)/
 	@cp -r server-configs $(NAME)-$(VERSION)/
 
+	# don't bundle external config
+	@rm $(NAME)-$(VERSION)/config/config.yml
+
 	# don't package engine bin directory, specs (no need) and .gitignore (OBS complains)
 	@rm -rf $(NAME)-$(VERSION)/engines/*/bin
 	@rm -rf $(NAME)-$(VERSION)/engines/*/test

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ This Ruby on Rails-bsed project uses [rvm](http://rvm.io/rvm/basics) to manage a
     sudo zypper in libxml2-devel libxslt-devel sqlite3-devel
     ```
 
+4.  Create a local config file
+    ```
+    cp config/config.yml.example config/config.yml
+    ```
+    Only an example config is included in the project for reference. Your working config is not included in the source repository.
+
 4.  Initialize a development database
     ```
     rails db:setup

--- a/app/models/concerns/authenticateable.rb
+++ b/app/models/concerns/authenticateable.rb
@@ -1,7 +1,7 @@
 # perform authentication based on the output of cloud-instance-credentials
 module Authenticateable
   def credentials
-    @credentials ||= File.read(Rails.application.config.nginx_pass_file).strip
+    @credentials ||= File.read(Rails.configuration.nginx_pass_file).strip
   end
 
   def username_is_valid?(username)
@@ -23,7 +23,7 @@ module Authenticateable
     Cheetah.run(
       %W(openssl passwd -apr1 -salt #{salt} #{password}),
       stdout: :capture,
-      logger: Logger.new(Rails.application.config.cli_log)
+      logger: Logger.new(Rails.configuration.cli_log)
     ).strip
   end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -29,7 +29,7 @@ class Resource < ApplicationRecord
           @failed = true
           message = "Status of #{ApplicationController.helpers.friendly_type(self.type)} #{self.id} failed, deployment interrupted. Please, go to the next page\n"
           Rails.logger.error message
-          Rails.application.config.lasso_error = message
+          Rails.configuration.lasso_error = message
           desired_status = status.to_sym
           next
         end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,15 +14,6 @@ module SUSERancherSetup
     # Asynchronous in-memory background job handler
     config.active_job.queue_adapter = :async
 
-    # Engines to load
-    # The order determines the menu order - engines with no UI should be last
-    config.engines = ['AWS', 'ShirtSize', 'RancherOnEks', 'Helm']
-
-    # Application-level menu entries
-    config.menu_entries = [
-      { caption: 'Login', icon: 'login', target: '/' },
-      { caption: 'Welcome', icon: 'home', target: '/welcome' }
-    ]
     config.lasso_run = "run"
     config.lasso_commands = "nil"
     config.lasso_error = ""
@@ -32,6 +23,18 @@ module SUSERancherSetup
     config.lasso_logged = false
     config.cli_log = 'log/cli.log'
     config.permissions_passed = false
+
+    # External configs: config.yml
+    ## Engines to load
+    ## The order determines the menu order - engines with no UI should be last
+    config.engines = config_for(:config)[:engines]
+    ## Application-level menu entries - these come before Engine UIs
+    config.menu_entries = [
+      { caption: 'Login', icon: 'login', target: '/' },
+      { caption: 'Welcome', icon: 'home', target: '/welcome' }
+    ]
+    # Rancher source - for _helm_
+    config.x.rancher = OpenStruct.new(config_for(:config)[:rancher])
   end
 end
 

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -1,0 +1,22 @@
+# SUSE Rancher Setup - external configuration
+# The commented keys will be loaded into the application configuration.
+# Only documented keys are accepted.
+
+shared:
+
+  # Which engines are loaded for this workflow?
+  # * Order determines menu order
+  # * Engines without UI components should be last
+  engines:
+    - AWS
+    - ShirtSize
+    - RancherOnEks
+    - Helm
+
+  # Where are we installing Rancher from? (passed to _helm_)
+  rancher:
+    repo_name: rancher-stable
+    repo_url: https://releases.rancher.com/server-charts/stable
+    chart: rancher-stable/rancher
+    release_name: rancher-stable
+    version:

--- a/engines/aws/app/controllers/aws/permissions_controller.rb
+++ b/engines/aws/app/controllers/aws/permissions_controller.rb
@@ -3,7 +3,7 @@ module AWS
     def show
       @metadata = AWS::Metadata.load()
       @permissions = AWS::Permissions.new(
-        source_policy_file: Rails.application.config.aws_iam_source_policy_path,
+        source_policy_file: Rails.configuration.aws_iam_source_policy_path,
         arn: @metadata.policy_source_arn()
       )
     rescue StandardError => error

--- a/engines/aws/app/models/aws/allocation_address.rb
+++ b/engines/aws/app/models/aws/allocation_address.rb
@@ -11,7 +11,7 @@ module AWS
 
     def aws_destroy
       @cli.release_address(self.id)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
 
       self.wait_until(:not_found)
     end

--- a/engines/aws/app/models/aws/cli.rb
+++ b/engines/aws/app/models/aws/cli.rb
@@ -23,7 +23,7 @@ module AWS
           'AWS_DEFAULT_REGION' => @region,
           'AWS_DEFAULT_OUTPUT' => 'json'
         },
-        logger: Logger.new(Rails.application.config.cli_log)
+        logger: Logger.new(Rails.configuration.cli_log)
       )
       raise StandardError.new(stderr) if stderr.present?
 
@@ -42,10 +42,10 @@ module AWS
     end
 
     def handle_command(args)
-      if Rails.application.config.lasso_run.present?
+      if Rails.configuration.lasso_run.present?
         execute(*args)
       else
-        File.open(Rails.application.config.lasso_commands_file, 'a') do |f|
+        File.open(Rails.configuration.lasso_commands_file, 'a') do |f|
           f.write "aws #{args.join(' ')} --region #{@region} --output json\n"
         end
       end
@@ -487,10 +487,10 @@ module AWS
       args = %W(
         route53 change-resource-record-sets
         --hosted-zone-id #{hosted_zone_id}
-        --change-batch file://#{Rails.application.config.lasso_dns_json_path}
+        --change-batch file://#{Rails.configuration.lasso_dns_json_path}
       )
       output = handle_command(args)
-      FileUtils.rm_f(Rails.application.config.lasso_dns_json_path)
+      FileUtils.rm_f(Rails.configuration.lasso_dns_json_path)
       output
     end
 
@@ -513,7 +513,7 @@ module AWS
           }
         ]
       }
-      File.open(Rails.application.config.lasso_dns_json_path, 'w') do |f|
+      File.open(Rails.configuration.lasso_dns_json_path, 'w') do |f|
         f.write(change_batch.to_json)
       end
     end
@@ -525,10 +525,10 @@ module AWS
       args = %W(
         route53 change-resource-record-sets
         --hosted-zone-id #{hosted_zone_id}
-        --change-batch file://#{Rails.application.config.lasso_dns_json_path}
+        --change-batch file://#{Rails.configuration.lasso_dns_json_path}
       )
       output = handle_command(args)
-      FileUtils.rm_f(Rails.application.config.lasso_dns_json_path)
+      FileUtils.rm_f(Rails.configuration.lasso_dns_json_path)
       output
     end
 

--- a/engines/aws/app/models/aws/cluster.rb
+++ b/engines/aws/app/models/aws/cluster.rb
@@ -17,7 +17,7 @@ module AWS
 
     def aws_destroy
       @cli.delete_cluster(self.id)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
 
       self.wait_until(:DELETING)
       self.wait_until(:not_found)

--- a/engines/aws/app/models/aws/internet_gateway.rb
+++ b/engines/aws/app/models/aws/internet_gateway.rb
@@ -20,7 +20,7 @@ module AWS
         @cli.detach_internet_gateway(attachment['VpcId'], self.id)
       end
       @cli.delete_internet_gateway(self.id)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
 
       self.wait_until(:not_found)
     end

--- a/engines/aws/app/models/aws/metadata.rb
+++ b/engines/aws/app/models/aws/metadata.rb
@@ -17,7 +17,7 @@ module AWS
         ['ec2metadata', '--api', 'latest', *args],
         stdout: :capture,
         stderr: :capture,
-        logger: Logger.new(Rails.application.config.cli_log)
+        logger: Logger.new(Rails.configuration.cli_log)
       )
       raise StandardError.new(stderr) if stderr.present?
 

--- a/engines/aws/app/models/aws/nat_gateway.rb
+++ b/engines/aws/app/models/aws/nat_gateway.rb
@@ -24,7 +24,7 @@ module AWS
 
     def aws_destroy
       @cli.delete_nat_gateway(self.id)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
 
       self.wait_until(:deleted)
     end

--- a/engines/aws/app/models/aws/node_group.rb
+++ b/engines/aws/app/models/aws/node_group.rb
@@ -24,7 +24,7 @@ module AWS
 
     def aws_destroy
       @cli.delete_node_group(self.id, @cluster_name)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
 
       self.wait_until(:not_found)
     end

--- a/engines/aws/app/models/aws/private_subnet.rb
+++ b/engines/aws/app/models/aws/private_subnet.rb
@@ -23,7 +23,7 @@ module AWS
 
     def aws_destroy
       @cli.delete_subnet(self.id)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
 
       self.wait_until(:not_found)
     end

--- a/engines/aws/app/models/aws/public_subnet.rb
+++ b/engines/aws/app/models/aws/public_subnet.rb
@@ -28,7 +28,7 @@ module AWS
 
     def aws_destroy
       @cli.delete_subnet(self.id)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
 
       self.wait_until(:not_found)
     end

--- a/engines/aws/app/models/aws/role.rb
+++ b/engines/aws/app/models/aws/role.rb
@@ -32,15 +32,15 @@ module AWS
     end
 
     def aws_destroy
-      original_lasso_run = Rails.application.config.lasso_run
-      Rails.application.config.lasso_run = "run"
+      original_lasso_run = Rails.configuration.lasso_run
+      Rails.configuration.lasso_run = "run"
       policies = JSON.parse(@cli.list_role_attached_policies(self.id))
-      Rails.application.config.lasso_run = original_lasso_run
+      Rails.configuration.lasso_run = original_lasso_run
       policies['AttachedPolicies'].each do |policy|
         @cli.detach_role_policy(self.id, policy['PolicyArn'])
       end
       @cli.delete_role(self.id)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
 
       self.wait_until(:not_found)
     end

--- a/engines/aws/app/models/aws/route_table.rb
+++ b/engines/aws/app/models/aws/route_table.rb
@@ -20,7 +20,7 @@ module AWS
         @cli.disassociate_route_table(association['RouteTableAssociationId'])
       end
       @cli.delete_route_table(self.id)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
 
       self.wait_until(:not_found)
     end

--- a/engines/aws/app/models/aws/security_group.rb
+++ b/engines/aws/app/models/aws/security_group.rb
@@ -11,7 +11,7 @@ module AWS
 
     def aws_destroy
       @cli.delete_security_group(self.id)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
     end
 
     def describe_resource

--- a/engines/aws/app/models/aws/vpc.rb
+++ b/engines/aws/app/models/aws/vpc.rb
@@ -18,7 +18,7 @@ module AWS
 
     def aws_destroy
       @cli.delete_vpc(self.id)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
 
       self.wait_until(:not_found)
     end

--- a/engines/aws/app/views/aws/permissions/show.html.haml
+++ b/engines/aws/app/views/aws/permissions/show.html.haml
@@ -1,7 +1,7 @@
 = page_header(t('engines.aws.permissions.title'))
 -# body
 %p= markdown(t('engines.aws.permissions.caption', arn: @metadata.policy_source_arn()))
-- if Rails.application.config.permissions_passed || @permissions.passed?
+- if Rails.configuration.permissions_passed || @permissions.passed?
   %p
     %b= t('engines.aws.permissions.passed')
 - else

--- a/engines/helm/app/models/helm/cert_manager.rb
+++ b/engines/helm/app/models/helm/cert_manager.rb
@@ -27,7 +27,7 @@ module Helm
 
     def helm_destroy
       @helm.delete_deployment(RELEASE_NAME, NAMESPACE)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
       # @kubectl.delete_namespace(NAMESPACE) # This never completes :(
     end
 

--- a/engines/helm/app/models/helm/cli.rb
+++ b/engines/helm/app/models/helm/cli.rb
@@ -23,7 +23,7 @@ module Helm
           'AWS_DEFAULT_OUTPUT' => 'json',
           'KUBECONFIG' => @kubeconfig
         },
-        logger: Logger.new(Rails.application.config.cli_log)
+        logger: Logger.new(Rails.configuration.cli_log)
       )
     end
 
@@ -85,12 +85,12 @@ module Helm
     end
 
     def handle_command(args)
-      if Rails.application.config.lasso_run.present?
+      if Rails.configuration.lasso_run.present?
         stdout, stderr = execute(*args)
         return stderr if stderr.present?
         return stdout
       else
-        File.open(Rails.application.config.lasso_commands_file, 'a') do |f|
+        File.open(Rails.configuration.lasso_commands_file, 'a') do |f|
           envs = "KUBECONFIG=#{@kubeconfig}"
           f.write "#{envs} helm #{args.join(' ')} --region #{@region} --output json\n"
         end

--- a/engines/helm/app/models/helm/ingress_controller.rb
+++ b/engines/helm/app/models/helm/ingress_controller.rb
@@ -29,7 +29,7 @@ module Helm
 
     def helm_destroy
       @helm.delete_deployment(RELEASE_NAME, NAMESPACE)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
       # @kubectl.delete_namespace(NAMESPACE) # This never completes :(
     end
 

--- a/engines/helm/app/models/k8s/cli.rb
+++ b/engines/helm/app/models/k8s/cli.rb
@@ -25,7 +25,7 @@ module K8s
           'AWS_DEFAULT_OUTPUT' => 'json',
           'KUBECONFIG' => @kubeconfig
         },
-        logger: Logger.new(Rails.application.config.cli_log)
+        logger: Logger.new(Rails.configuration.cli_log)
       )
     end
 

--- a/engines/rancher_on_eks/app/controllers/rancher_on_eks/steps_controller.rb
+++ b/engines/rancher_on_eks/app/controllers/rancher_on_eks/steps_controller.rb
@@ -9,8 +9,8 @@ module RancherOnEks
       @complete = Step.all_complete?
       @resources = Resource.all
       redirect_to rancher_on_eks.wrapup_path if @complete
-      if Rails.application.config.lasso_error != "" && Rails.application.config.lasso_error != "error-cleanup"
-        flash.now[:danger] = Rails.application.config.lasso_error
+      if Rails.configuration.lasso_error != "" && Rails.configuration.lasso_error != "error-cleanup"
+        flash.now[:danger] = Rails.configuration.lasso_error
         @deploy_failed = true
         @complete = true
       end
@@ -18,8 +18,8 @@ module RancherOnEks
     end
 
     def deploy
-      Rails.application.config.lasso_run = true
-      Rails.application.config.lasso_commands = "nil"
+      Rails.configuration.lasso_run = true
+      Rails.configuration.lasso_commands = "nil"
       @steps.find_by_rank(0).start!
       RancherOnEks::DeployerJob.perform_later()
       redirect_to rancher_on_eks.steps_path

--- a/engines/rancher_on_eks/app/controllers/rancher_on_eks/wrapup_controller.rb
+++ b/engines/rancher_on_eks/app/controllers/rancher_on_eks/wrapup_controller.rb
@@ -4,7 +4,7 @@ module RancherOnEks
     def show
       download_file if params[:download]
 
-      @lasso_commands = ["done"].include? Rails.application.config.lasso_commands
+      @lasso_commands = ["done"].include? Rails.configuration.lasso_commands
       @resources_deleted = Step.all_deleted?
       @in_process = params[:deleting] && !@resources_deleted
       @fqdn = RancherOnEks::Fqdn.load.value
@@ -18,20 +18,20 @@ module RancherOnEks
       @cleaning_up = params[:deleting]
       # keep showing the buttons after cleaning up
       @resources_created = @resources.length > 0 || params[:deleting]
-      @downloading = ["running"].include? Rails.application.config.lasso_commands
+      @downloading = ["running"].include? Rails.configuration.lasso_commands
       @refresh_timer = 15 if @in_process || @downloading
-      if @lasso_commands && File.exist?(Rails.application.config.lasso_commands_file)
+      if @lasso_commands && File.exist?(Rails.configuration.lasso_commands_file)
         @commands = get_commands
       end
-      @failed = true if Rails.application.config.lasso_error != ""
+      @failed = true if Rails.configuration.lasso_error != ""
     end
 
     def destroy
-      Rails.application.config.lasso_run = params[:run]
-      deleting = true if Rails.application.config.lasso_run.present?
+      Rails.configuration.lasso_run = params[:run]
+      deleting = true if Rails.configuration.lasso_run.present?
 
-      Rails.application.config.lasso_commands = "running" unless deleting
-      File.delete(Rails.application.config.lasso_commands_file) unless deleting || !File.exist?(Rails.application.config.lasso_commands_file)
+      Rails.configuration.lasso_commands = "running" unless deleting
+      File.delete(Rails.configuration.lasso_commands_file) unless deleting || !File.exist?(Rails.configuration.lasso_commands_file)
       RancherOnEks::WrapupJob.perform_later()
       redirect_to rancher_on_eks.wrapup_path(deleting: deleting)
     end
@@ -47,14 +47,14 @@ module RancherOnEks
     end
 
     def download_file
-      compressed_filestream = zip_files(Rails.application.config.lasso_commands_file)
+      compressed_filestream = zip_files(Rails.configuration.lasso_commands_file)
       @zip_name = "#{t('engines.rancher_on_eks.wrapup.clean_resources_file').downcase.gsub(' ', '_')}"\
         "-#{DateTime.now.iso8601}.zip"
       send_data compressed_filestream.read, filename: @zip_name
     end
 
     def get_commands
-      File.open(Rails.application.config.lasso_commands_file, 'r') { |f| f.readlines }
+      File.open(Rails.configuration.lasso_commands_file, 'r') { |f| f.readlines }
     end
   end
 end

--- a/engines/rancher_on_eks/app/helpers/rancher_on_eks/authorization_helper.rb
+++ b/engines/rancher_on_eks/app/helpers/rancher_on_eks/authorization_helper.rb
@@ -48,14 +48,14 @@ module RancherOnEks
     end
 
     def has_permissions?
-      return true if Rails.application.config.permissions_passed
+      return true if Rails.configuration.permissions_passed
 
       metadata = AWS::Metadata.load()
       permissions = AWS::Permissions.new(
-        source_policy_file: Rails.application.config.aws_iam_source_policy_path,
+        source_policy_file: Rails.configuration.aws_iam_source_policy_path,
         arn: metadata.policy_source_arn()
       )
-      Rails.application.config.permissions_passed = permissions.passed?
+      Rails.configuration.permissions_passed = permissions.passed?
     rescue
       false
     end

--- a/engines/rancher_on_eks/app/jobs/rancher_on_eks/deployer_job.rb
+++ b/engines/rancher_on_eks/app/jobs/rancher_on_eks/deployer_job.rb
@@ -15,13 +15,13 @@ module RancherOnEks
     def handle_cli_exception(exception)
       if exception.class == Cheetah::ExecutionFailed
         Rails.logger.error exception.stderr
-        Rails.application.config.lasso_error = exception.stderr
+        Rails.configuration.lasso_error = exception.stderr
       elsif exception.class == StandardError
         Rails.logger.error exception.message
-        Rails.application.config.lasso_error = exception.message
+        Rails.configuration.lasso_error = exception.message
       else
         Rails.logger.error exception
-        Rails.application.config.lasso_error = exception
+        Rails.configuration.lasso_error = exception
       end
     end
   end

--- a/engines/rancher_on_eks/app/jobs/rancher_on_eks/wrapup_job.rb
+++ b/engines/rancher_on_eks/app/jobs/rancher_on_eks/wrapup_job.rb
@@ -3,8 +3,8 @@ module RancherOnEks
     queue_as :default
 
     after_perform do |job|
-      Rails.application.config.lasso_commands = "done" if Rails.application.config.lasso_run != "true"
-      Rails.application.config.lasso_error = "error-cleanup" if Rails.application.config.lasso_error != "" # special value in case there were errors
+      Rails.configuration.lasso_commands = "done" if Rails.configuration.lasso_run != "true"
+      Rails.configuration.lasso_error = "error-cleanup" if Rails.configuration.lasso_error != "" # special value in case there were errors
     end
 
     def perform(*args)

--- a/engines/rancher_on_eks/app/models/rancher_on_eks/custom_config.rb
+++ b/engines/rancher_on_eks/app/models/rancher_on_eks/custom_config.rb
@@ -12,19 +12,19 @@ module RancherOnEks
     def self.load
       new(
         repo_name: KeyValue.get(
-          :rancher_repo_name, Rails.application.config.x.rancher.repo_name
+          :rancher_repo_name, Rails.configuration.x.rancher.repo_name
         ),
         repo_url: KeyValue.get(
-          :rancher_repo_url, Rails.application.config.x.rancher.repo_url
+          :rancher_repo_url, Rails.configuration.x.rancher.repo_url
         ),
         chart: KeyValue.get(
-          :rancher_chart, Rails.application.config.x.rancher.chart
+          :rancher_chart, Rails.configuration.x.rancher.chart
         ),
         release_name: KeyValue.get(
-          :rancher_release_name, Rails.application.config.x.rancher.release_name
+          :rancher_release_name, Rails.configuration.x.rancher.release_name
         ),
         version: KeyValue.get(
-          :rancher_version, Rails.application.config.x.rancher.version
+          :rancher_version, Rails.configuration.x.rancher.version
         )
       )
     end

--- a/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
+++ b/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
@@ -117,7 +117,7 @@ module RancherOnEks
     end
 
     def step(rank, force: false)
-      raise StandardError.new("Creating #{ApplicationController.helpers.friendly_type(@type)}: status failed") if Rails.application.config.lasso_error.present? && Rails.application.config.lasso_error != "error-cleanup"
+      raise StandardError.new("Creating #{ApplicationController.helpers.friendly_type(@type)}: status failed") if Rails.configuration.lasso_error.present? && Rails.configuration.lasso_error != "error-cleanup"
 
       step = Step.find_by(rank: rank)
       return if step.complete? && !force
@@ -313,13 +313,13 @@ module RancherOnEks
         @rancher.wait_until(:deployed)
       end
       # in case Rancher create command gets failed status
-      raise StandardError.new("Creating #{ApplicationController.helpers.friendly_type(@type)}: status failed") if Rails.application.config.lasso_error.present? && Rails.application.config.lasso_error != "error-cleanup"
+      raise StandardError.new("Creating #{ApplicationController.helpers.friendly_type(@type)}: status failed") if Rails.configuration.lasso_error.present? && Rails.configuration.lasso_error != "error-cleanup"
     end
 
     def self.rollback
       Step.all.order(rank: :desc).each do |step|
         step.resource&.destroy
-        step.destroy if Rails.application.config.lasso_run.present?
+        step.destroy if Rails.configuration.lasso_run.present?
       end
     end
   end

--- a/engines/rancher_on_eks/app/models/rancher_on_eks/rancher.rb
+++ b/engines/rancher_on_eks/app/models/rancher_on_eks/rancher.rb
@@ -18,11 +18,11 @@ module RancherOnEks
     private
 
     def helm_create
-      @repo_name ||= Rails.application.config.x.rancher.repo_name
-      @repo_url ||= Rails.application.config.x.rancher.repo_url
-      @chart ||= Rails.application.config.x.rancher.chart
-      @release_name ||= Rails.application.config.x.rancher.release_name
-      @version ||= Rails.application.config.x.rancher.version
+      @repo_name ||= Rails.configuration.x.rancher.repo_name
+      @repo_url ||= Rails.configuration.x.rancher.repo_url
+      @chart ||= Rails.configuration.x.rancher.chart
+      @release_name ||= Rails.configuration.x.rancher.release_name
+      @version ||= Rails.configuration.x.rancher.version
 
       @kubectl.create_namespace(NAMESPACE)
       @helm.add_repo(@repo_name, @repo_url)
@@ -44,7 +44,7 @@ module RancherOnEks
 
     def helm_destroy
       @helm.delete_deployment(self.id, NAMESPACE)
-      throw(:abort) unless Rails.application.config.lasso_run.present?
+      throw(:abort) unless Rails.configuration.lasso_run.present?
 
       # @kubectl.delete_namespace(NAMESPACE) # This never completes :(
     end

--- a/engines/rancher_on_eks/config/initializers/aws_iam.rb
+++ b/engines/rancher_on_eks/config/initializers/aws_iam.rb
@@ -1,1 +1,1 @@
-Rails.application.config.aws_iam_source_policy_path = File.join(Rails.root, 'aws-iam', 'iam_role.json')
+Rails.configuration.aws_iam_source_policy_path = File.join(Rails.root, 'aws-iam', 'iam_role.json')

--- a/engines/rancher_on_eks/config/initializers/default_rancher_install.rb
+++ b/engines/rancher_on_eks/config/initializers/default_rancher_install.rb
@@ -1,6 +1,0 @@
-Rails.application.config.x.rancher.repo_name ||= 'rancher-stable'
-Rails.application.config.x.rancher.repo_url ||=
-  'https://releases.rancher.com/server-charts/stable'
-Rails.application.config.x.rancher.chart ||= 'rancher-stable/rancher'
-Rails.application.config.x.rancher.release_name ||= 'rancher-stable'
-Rails.application.config.x.rancher.version ||= ''


### PR DESCRIPTION
A yaml file injected into the config dir as `config.yml` will supply the workflow & rancher install source for _helm_. A well-documented example is included, while the config itself is explicitly excluded from source control and packaging.