### PR TITLE
Manage changelog the right way

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ _Please note any new external CLI dependencies in this documentation._
 
 Update the [changelog](packaging/suse-rancher-setup.changes) for the expected release version, and stage it for _git_.
 
-**💡 Hint:** You can use `date -u` to get the proper date format for changelogs.
+**💡 Hint:** You can use `bin/vc` to get the proper format for changelogs, assuming you have [_osc_](https://software.opensuse.org/package/osc) installed.
 
 
 [bumpversion](https://pypi.org/project/bumpversion/) is used to tag releases; the `--allow-dirty` flag will include the _changelog_ in the version bump commit.

--- a/bin/vc
+++ b/bin/vc
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+VC_REALNAME=`git config --get user.name`
+VC_MAILADDR=`git config --get user.email`
+
+cd ./packaging
+/usr/lib/build/vc suse-rancher-setup.changes $@


### PR DESCRIPTION
Use the `osc`-provided `vc` command to edit changelog. No more fetching dates, no more missing whitespace.