### PR TITLE
Set the AWS IMDS API to a specific version

### DIFF
--- a/engines/aws/app/models/aws/metadata.rb
+++ b/engines/aws/app/models/aws/metadata.rb
@@ -14,7 +14,7 @@ module AWS
 
     def execute(*args)
       stdout, stderr = Cheetah.run(
-        ['ec2metadata', '--api', 'latest', *args],
+        ['ec2metadata', '--api', '2021-07-15', *args],
         stdout: :capture,
         stderr: :capture,
         logger: Logger.new(Rails.configuration.cli_log)


### PR DESCRIPTION
... instead of using 'latest'. Resolves #127

```
ec2-user@ip-192-168-10-205:~> ec2metadata --api 2021-07-15 --info
{
  "Code" : "Success",
  "LastUpdated" : "2022-10-05T15:23:49Z",
  "InstanceProfileArn" : "arn:aws:iam::[REDACTED]:instance-profile/lasso-test",
  "InstanceProfileId" : "[REDACTED]"
}
ec2-user@ip-REDACTED:~> ec2metadata --api latest --info
{
  "Code" : "Success",
  "LastUpdated" : "2022-10-05T15:23:33Z",
  "AccountId" : "[REDACTED]"
}
```