### PR TITLE
AKS Workflow: step 4/8

### DIFF
--- a/engines/azure/app/models/azure/cli.rb
+++ b/engines/azure/app/models/azure/cli.rb
@@ -116,12 +116,15 @@ module Azure
       )
     end
 
-    def update_kubeconfig(cluster_name:, resource_group_name:)
+    def update_kubeconfig(cluster_name:, resource_group_name:, kubeconfig: '/tmp/kubeconfig')
       self.execute(
         %W(
           aks get-credentials
           --name #{cluster_name}
           --resource-group #{resource_group_name}
+          --admin
+          --file #{kubeconfig}
+          --overwrite-existing
         )
       )
     end

--- a/engines/helm/app/models/helm/cli.rb
+++ b/engines/helm/app/models/helm/cli.rb
@@ -7,22 +7,25 @@ module Helm
 
     def self.load
       new(
-        region: AWS::Region.load().value,
+        region: (AWS::Region.load().value if defined?(AWS::Engine)),
         kubeconfig: '/tmp/kubeconfig'
       )
     end
 
     def execute(*args)
+      env = {
+        'KUBECONFIG' => @kubeconfig
+      }
+      if defined?(AWS::Engine)
+        env['AWS_REGION'] = @region
+        env['AWS_DEFAULT_REGION'] = @region
+        env['AWS_DEFAULT_OUTPUT'] = 'json'
+      end
       stdout, stderr = Cheetah.run(
         ['helm', *args],
         stdout: :capture,
         stderr: :capture,
-        env: {
-          'AWS_REGION' => @region,
-          'AWS_DEFAULT_REGION' => @region,
-          'AWS_DEFAULT_OUTPUT' => 'json',
-          'KUBECONFIG' => @kubeconfig
-        },
+        env: env,
         logger: Logger.new(Rails.configuration.cli_log)
       )
     end

--- a/engines/rancher_on_aks/app/models/rancher_on_aks/deployment.rb
+++ b/engines/rancher_on_aks/app/models/rancher_on_aks/deployment.rb
@@ -76,6 +76,10 @@ module RancherOnAks
         )
         nil
       end
+      step(4) do
+        @ingress = Helm::IngressController.create()
+        @ingress.wait_until(:deployed)
+      end
       Rails.configuration.lasso_deploy_complete = true
     end
   end


### PR DESCRIPTION
* Fix up the Helm engine to not be dependent on AWS. 
* Fix up the kubeconfig export to be more consistent with other engines.
* Finally, deploy the ingress-controller on AKS.