### PR TITLE
Option for Let's Encrypt cert on Rancher server - RancherOnEKS Workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem 'active_link_to'
 # zip files
 gem 'rubyzip', require: 'zip'
 
+# email address validation
+gem 'email_validator'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile
+++ b/Gemfile
@@ -83,4 +83,6 @@ group :test do
 
   gem 'simplecov'
   gem 'simplecov-json'
+
+  gem 'faker'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
     email_validator (2.2.4)
       activemodel
     erubi (1.11.0)
+    faker (3.0.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -271,6 +273,7 @@ DEPENDENCIES
   cheetah
   debug
   email_validator
+  faker
   haml-rails
   importmap-rails
   jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    email_validator (2.2.4)
+      activemodel
     erubi (1.11.0)
     ffi (1.15.5)
     globalid (1.0.0)
@@ -268,6 +270,7 @@ DEPENDENCIES
   capybara
   cheetah
   debug
+  email_validator
   haml-rails
   importmap-rails
   jbuilder

--- a/app/models/tls_source.rb
+++ b/app/models/tls_source.rb
@@ -29,7 +29,7 @@ class TlsSource
 
   def source_options
     [
-      ["Rancher self-signed certificate", 'rancher', ],
+      ["Rancher self-signed certificate", 'rancher'],
       ["Let's Encrypt certificate", 'letsEncrypt']
     ]
   end

--- a/app/models/tls_source.rb
+++ b/app/models/tls_source.rb
@@ -1,0 +1,36 @@
+class TlsSource
+  include ActiveModel::Model
+  include Saveable
+
+  SOURCE_OPTIONS = %w(rancher letsEncrypt)
+
+  attr_accessor :source, :email_address
+  validates :source, allow_nil: true, inclusion: {
+    in: SOURCE_OPTIONS,
+    message: "'%{value}' is not valid."
+  }
+  with_options if: -> { source == 'letsEncrypt' } do |instance|
+    instance.validates :email_address, presence: true
+    instance.validates :email_address, email: true
+  end
+
+  def self.load
+    new(
+      source: KeyValue.get(:tls_source),
+      email_address: KeyValue.get(:tls_email_address)
+    )
+  end
+
+  def save!
+    self.validate!
+    KeyValue.set(:tls_source, @source)
+    KeyValue.set(:tls_email_address, @email_address)
+  end
+
+  def source_options
+    [
+      ["Rancher self-signed certificate", 'rancher', ],
+      ["Let's Encrypt certificate", 'letsEncrypt']
+    ]
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
     using_fqdn: "Rancher will be served at 'https://%{fqdn}'."
     login_required: "You must log in first."
     not_authorized: "You cannot perform this step yet."
+    tls_source: "Rancher will use '%{source}' as the TLS certificate source."
 
   resources:
     caption: "The following resources were created as part of your deployment:"
@@ -78,6 +79,10 @@ en:
           attributes:
             base:
               invalid: "Credentials are not valid."
+    attributes:
+      tls_source:
+        source: "TLS certificate source"
+        email_address: "Email address for certificate management (Let's Encrypt only)"
 
   workflow:
     rancher_on_aks:
@@ -221,6 +226,16 @@ en:
 
 
           The subdomain containing this *FQDN* _must be preconfigured as an AWS Route53 hosted zone_. For example, if the *FQDN* is `rancher.example.com`, then `example.com` must be a Route53 hosted zone, and Rancher will be served at `https://rancher.example.com` .
+      security:
+        title: "Security options"
+        form_caption: |-
+          The Rancher management server is designed to be secure by default and requires SSL/TLS configuration.
+
+
+          You can choose to use a self-signed TLS certificate provided by the Rancher server, or you may choose to have a [Let's Encrypt](https://letsencrypt.org/) certificate generated for to it.
+
+
+          **NOTE:** *In order for Let's Encrypt to generate a TLS certificate, your Rancher server must be accessible via the Internet at the FQDN provided over TCP port 80 (http), and you must supply an email address for future management.*
       wrapup:
         title: "Congratulations - your Rancher server is ready!"
         failed_title: "Oh no! Your Rancher deployment has failed!"

--- a/engines/helm/app/models/helm/rancher.rb
+++ b/engines/helm/app/models/helm/rancher.rb
@@ -6,11 +6,17 @@ module Helm
 
     attr_accessor :fqdn, :repo_name, :repo_url, :chart, :release_name, :version
 
-    attr_accessor :tls_source
+    # https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster#5-install-rancher-with-helm-and-your-chosen-certificate-option
+    attr_accessor :tls_source, :email_address
     validates :tls_source, allow_nil: true, inclusion: {
       in: %w(rancher letsEncrypt secret),
       message: "'%{value}' is not valid."
     }
+    with_options if: -> { tls_source == 'letsEncrypt' } do |instance|
+      instance.validates :email_address, presence: true
+      instance.validates :email_address, email: true
+    end
+
 
     def initial_password
       args = %W(
@@ -47,10 +53,12 @@ module Helm
       if @tls_source
         args.push(*%W(--set ingress.tls.source=#{@tls_source}))
       end
+      if @tls_source == 'letsEncrypt'
+        args.push(*%W(--set letsEncrypt.email=#{@email_address}))
+      end
       @helm.install(@release_name, @chart, NAMESPACE, args)
       self.id = @release_name
       self.refresh()
-      #
     end
 
     def helm_destroy

--- a/engines/helm/app/models/helm/rancher.rb
+++ b/engines/helm/app/models/helm/rancher.rb
@@ -1,7 +1,5 @@
 module Helm
   class Rancher < HelmResource
-    include ActiveModel::Validations
-
     NAMESPACE = 'cattle-system'
 
     attr_accessor :fqdn, :repo_name, :repo_url, :chart, :release_name, :version

--- a/engines/rancher_on_eks/app/controllers/rancher_on_eks/security_controller.rb
+++ b/engines/rancher_on_eks/app/controllers/rancher_on_eks/security_controller.rb
@@ -1,0 +1,24 @@
+module RancherOnEks
+  class SecurityController < RancherOnEks::ApplicationController
+    def edit
+      @tls_source = TlsSource.load
+    end
+
+    def update
+      @tls_source = TlsSource.new(self.security_params)
+      if @tls_source.save
+        flash[:success] = t('flash.tls_source', source: @tls_source.source)
+        redirect_to(helpers.next_step_path(rancher_on_eks.edit_security_path))
+      else
+        flash[:warning] = @tls_source.errors.full_messages
+        redirect_to(rancher_on_eks.edit_security_path)
+      end
+    end
+
+    private
+
+    def security_params
+      params.require(:tls_source).permit(:source, :email_address)
+    end
+  end
+end

--- a/engines/rancher_on_eks/app/helpers/rancher_on_eks/authorization_helper.rb
+++ b/engines/rancher_on_eks/app/helpers/rancher_on_eks/authorization_helper.rb
@@ -22,8 +22,10 @@ module RancherOnEks
         valid_login? && region_set?
       when rancher_on_eks.edit_fqdn_path, rancher_on_eks.fqdn_path
         valid_login? && region_set?
-      when rancher_on_eks.steps_path, rancher_on_eks.deploy_steps_path
+      when rancher_on_eks.edit_security_path, rancher_on_eks.security_path
         valid_login? && fqdn_set?
+      when rancher_on_eks.steps_path, rancher_on_eks.deploy_steps_path
+        valid_login? && security_set?
       when rancher_on_eks.wrapup_path
         valid_login? && setup_done?
       else
@@ -39,6 +41,10 @@ module RancherOnEks
     def fqdn_set?
       fqdn = RancherOnEks::Fqdn.load
       fqdn.value.present?
+    end
+
+    def security_set?
+      TlsSource.load.source.present?
     end
 
     def current_user

--- a/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
+++ b/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
@@ -285,13 +285,16 @@ module RancherOnEks
       step(24) do
         @fqdn_record ||= Step.find_by_rank(22).resource
         @custom_config = RancherOnEks::CustomConfig.load
+        @tls_source = TlsSource.load()
         @rancher = Helm::Rancher.create(
           fqdn: @fqdn_record.id,
           repo_name: @custom_config.repo_name,
           repo_url: @custom_config.repo_url,
           chart: @custom_config.chart,
           release_name: @custom_config.release_name,
-          version: @custom_config.version
+          version: @custom_config.version,
+          tls_source: @tls_source.source,
+          email_address: @tls_source.email_address
         )
         @type = @rancher.type
         @rancher.wait_until(:deployed)

--- a/engines/rancher_on_eks/app/views/rancher_on_eks/security/edit.html.haml
+++ b/engines/rancher_on_eks/app/views/rancher_on_eks/security/edit.html.haml
@@ -1,0 +1,13 @@
+= page_header(t('engines.rancher_on_eks.security.title'))
+-# body
+= form_with(model: @tls_source, url: rancher_on_eks.security_path, method: 'put') do |form|
+  = markdown(t('engines.rancher_on_eks.security.form_caption'))
+  %div.form-group
+    = form.label(:source, TlsSource.human_attribute_name(:source))
+    = form.select(:source, @tls_source.source_options, {}, { class: 'custom-select' })
+  %div.form-group
+    = form.label(:email_address, TlsSource.human_attribute_name(:email_address))
+    = form.email_field(:email_address, class: 'form-control')
+  = render('layouts/navigation_buttons') do
+    = previous_step_button()
+    = form.submit t('actions.next'), class: 'btn btn-primary'

--- a/engines/rancher_on_eks/config/routes.rb
+++ b/engines/rancher_on_eks/config/routes.rb
@@ -1,6 +1,8 @@
 RancherOnEks::Engine.routes.draw do
   resource :fqdn, controller: 'fqdn', only: [:edit, :update]
 
+  resource :security, controller: 'security', only: [:edit, :update]
+
   resources :steps do
     collection do
       post 'deploy'

--- a/engines/rancher_on_eks/lib/rancher_on_eks.rb
+++ b/engines/rancher_on_eks/lib/rancher_on_eks.rb
@@ -4,9 +4,10 @@ require "rancher_on_eks/engine"
 module RancherOnEks
   def self.menu_entries
     [
-      { caption: 'Domain Name', icon: 'read_more', target: '/deploy/fqdn/edit'},
-      { caption: 'Deploy', icon: 'deploy', target: '/deploy/steps'},
-      { caption: 'Next Steps', icon: 'enhancement', target: '/deploy/wrapup'}
+      { caption: 'Domain Name', icon: 'read_more', target: '/deploy/fqdn/edit' },
+      { caption: 'Security Options', icon: 'lock', target: '/deploy/security/edit' },
+      { caption: 'Deploy', icon: 'deploy', target: '/deploy/steps' },
+      { caption: 'Next Steps', icon: 'enhancement', target: '/deploy/wrapup' }
     ]
   end
 end

--- a/spec/models/tls_source_spec.rb
+++ b/spec/models/tls_source_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe TlsSource, :type => :model do
+  context 'on create' do
+    let(:tls_source) { 'rancher' }
+    let(:lets_encrypt_tls_source) { 'letsEncrypt' }
+    let(:invalid_string) { Faker::String.random }
+    let(:email_address) { Faker::Internet.email }
+
+    it 'stores the TLS source' do
+      subject.source = tls_source
+      subject.save
+
+      expect(TlsSource.load.source)
+        .to eq(tls_source)
+    end
+
+    it 'stores the email address' do
+      subject.email_address = email_address
+      subject.save
+
+      expect(TlsSource.load.email_address)
+        .to eq(email_address)
+    end
+
+    it 'validates the TLS source' do
+      subject.source = invalid_string
+
+      expect { subject.save! }
+        .to raise_error(ActiveModel::ValidationError)
+    end
+
+    context 'with lets-encrypt as source' do
+      before do
+        subject.source = lets_encrypt_tls_source
+      end
+
+      it 'requires an email address' do
+        subject.email_address = nil
+
+        expect { subject.save! }
+          .to raise_error(ActiveModel::ValidationError)
+      end
+
+      it 'validates the email address' do
+        subject.email_address = invalid_string
+
+        expect { subject.save! }
+          .to raise_error(ActiveModel::ValidationError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* New top-level TlsSource model stores TLS Source attributes with as much validation as I can manage
* Helm::Rancher model passes along TLS Source attributes as additional Helm arguments, per
https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster#5-install-rancher-with-helm-and-your-chosen-certificate-option
* New UI step: ":lock: Security Options"

UI Screenshots:
![lasso-lets-encrypt-1](https://user-images.githubusercontent.com/108494/208202889-e73e4df7-c0a1-4dac-83ca-14708e621169.png)
![lasso-lets-encrypt-2](https://user-images.githubusercontent.com/108494/208202895-4a561ef1-bee3-45f8-ac6f-496c2e11e712.png)

Test Result :tada: :
![lasso-lets-encrypt-3](https://user-images.githubusercontent.com/108494/208202901-a6ca3416-a988-432d-bd7d-ebbf8dc8885f.png)

Resolves #118 
