### PR TITLE
Don't attach helm resources to steps

### DIFF
--- a/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
+++ b/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
@@ -266,6 +266,7 @@ module RancherOnEks
         @ingress = Helm::IngressController.create()
         @type = @ingress.type
         @ingress.wait_until(:deployed)
+        nil
       end
       step(22) do
         @ingress ||= Step.find_by_rank(21).resource
@@ -281,6 +282,7 @@ module RancherOnEks
         @cert_manager = Helm::CertManager.create()
         @type = @cert_manager.type
         @cert_manager.wait_until(:deployed)
+        nil
       end
       step(24) do
         @fqdn_record ||= Step.find_by_rank(22).resource
@@ -298,6 +300,7 @@ module RancherOnEks
         )
         @type = @rancher.type
         @rancher.wait_until(:deployed)
+        nil
       end
       Rails.configuration.lasso_deploy_complete = true
       # in case Rancher create command gets failed status


### PR DESCRIPTION
Cleanup is based on removing resources associated with steps, in reverse order. But, there is no need to cleanup helm-created resources, as they will all be destroyed with the cluster nodegroup is cleaned up, so we can avoid wasting time cleaning them up, or giving the user unnecessary instructions at cleanup.