### PR TITLE
Add Lets-Encrypt TLS option for Rancher on AKS workflow

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,6 +209,16 @@ en:
 
 
           The subdomain containing this *FQDN* _must be preconfigured as an Azure DNS zone_. For example, if the *FQDN* is `rancher.example.com`, then `example.com` must be an Azure DNS zone, and Rancher will be served at `https://rancher.example.com` .
+      security:
+        title: "Security options"
+        form_caption: |-
+          The Rancher management server is designed to be secure by default and requires SSL/TLS configuration.
+
+
+          You can choose to use a self-signed TLS certificate provided by the Rancher server, or you may choose to have a [Let's Encrypt](https://letsencrypt.org/) certificate generated for to it.
+
+
+          **NOTE:** *In order for Let's Encrypt to generate a TLS certificate, your Rancher server must be accessible via the Internet at the FQDN provided over TCP port 80 (http), and you must supply an email address for future management.*
       steps:
         title: "Deploy Rancher on AKS"
         form_caption: "Okay, we have everything we need. It's time to deploy your Rancher server on a dedicated AKS cluster. When you're ready to start, just click **Next**, and sit back. Your Rancher server will be ready in about 20 minutes, and we'll tell you how to access it."

--- a/engines/rancher_on_aks/app/controllers/rancher_on_aks/security_controller.rb
+++ b/engines/rancher_on_aks/app/controllers/rancher_on_aks/security_controller.rb
@@ -1,0 +1,24 @@
+module RancherOnAks
+  class SecurityController < RancherOnAks::ApplicationController
+    def edit
+      @tls_source = TlsSource.load
+    end
+
+    def update
+      @tls_source = TlsSource.new(self.security_params)
+      if @tls_source.save
+        flash[:success] = t('flash.tls_source', source: @tls_source.source)
+        redirect_to(helpers.next_step_path(rancher_on_aks.edit_security_path))
+      else
+        flash[:warning] = @tls_source.errors.full_messages
+        redirect_to(rancher_on_aks.edit_security_path)
+      end
+    end
+
+    private
+
+    def security_params
+      params.require(:tls_source).permit(:source, :email_address)
+    end
+  end
+end

--- a/engines/rancher_on_aks/app/helpers/rancher_on_aks/authorization_helper.rb
+++ b/engines/rancher_on_aks/app/helpers/rancher_on_aks/authorization_helper.rb
@@ -20,8 +20,10 @@ module RancherOnAks
         valid_login? && region_set?
       when rancher_on_aks.edit_fqdn_path, rancher_on_aks.fqdn_path
         valid_login? && region_set?
-      when pre_flight.checks_path, pre_flight.retry_checks_path
+      when rancher_on_aks.edit_security_path, rancher_on_aks.security_path
         valid_login? && fqdn_set?
+      when pre_flight.checks_path, pre_flight.retry_checks_path
+        valid_login? && security_set?
       when rancher_on_aks.steps_path, rancher_on_aks.deploy_steps_path
         valid_login? && all_checks_passed?
       when rancher_on_aks.wrapup_path
@@ -45,6 +47,10 @@ module RancherOnAks
 
     def fqdn_set?
       RancherOnAks::Fqdn.load.value.present?
+    end
+
+    def security_set?
+      TlsSource.load.source.present?
     end
 
     def all_checks_passed?

--- a/engines/rancher_on_aks/app/models/rancher_on_aks/deployment.rb
+++ b/engines/rancher_on_aks/app/models/rancher_on_aks/deployment.rb
@@ -64,6 +64,7 @@ module RancherOnAks
           @zones = zones
         end
         @fqdn = RancherOnAks::Fqdn.load()
+        @tls_source = TlsSource.load()
         nil
       end
       step(1) do
@@ -117,7 +118,9 @@ module RancherOnAks
       end
       step(8) do
         @rancher = Helm::Rancher.create(
-          fqdn: @fqdn
+          fqdn: @fqdn,
+          tls_source: @tls_source.source,
+          email_address: @tls_source.email_address
         )
         @rancher.ready!
         nil

--- a/engines/rancher_on_aks/app/views/rancher_on_aks/security/edit.html.haml
+++ b/engines/rancher_on_aks/app/views/rancher_on_aks/security/edit.html.haml
@@ -1,0 +1,13 @@
+= page_header(t('engines.rancher_on_aks.security.title'))
+-# body
+= form_with(model: @tls_source, url: rancher_on_aks.security_path, method: 'put') do |form|
+  = markdown(t('engines.rancher_on_aks.security.form_caption'))
+  %div.form-group
+    = form.label(:source, TlsSource.human_attribute_name(:source))
+    = form.select(:source, @tls_source.source_options, {}, { class: 'custom-select' })
+  %div.form-group
+    = form.label(:email_address, TlsSource.human_attribute_name(:email_address))
+    = form.email_field(:email_address, class: 'form-control')
+  = render('layouts/navigation_buttons') do
+    = previous_step_button()
+    = form.submit t('actions.next'), class: 'btn btn-primary'

--- a/engines/rancher_on_aks/config/routes.rb
+++ b/engines/rancher_on_aks/config/routes.rb
@@ -1,5 +1,8 @@
 RancherOnAks::Engine.routes.draw do
   resource :fqdn, controller: 'fqdn', only: [:edit, :update]
+
+  resource :security, controller: 'security', only: [:edit, :update]
+
   resources :steps do
     collection do
       post 'deploy'

--- a/engines/rancher_on_aks/lib/rancher_on_aks.rb
+++ b/engines/rancher_on_aks/lib/rancher_on_aks.rb
@@ -5,6 +5,7 @@ module RancherOnAks
   def self.menu_entries
     [
       { caption: 'Domain Name', icon: 'read_more', target: '/deploy/fqdn/edit'},
+      { caption: 'Security Options', icon: 'lock', target: '/deploy/security/edit' },
       PreFlight.menu_entry,
       { caption: 'Deploy', icon: 'deploy', target: '/deploy/steps'},
       { caption: 'Next Steps', icon: 'enhancement', target: '/deploy/wrapup'}

--- a/spec/system/RancherOnAks/happy_path_spec.rb
+++ b/spec/system/RancherOnAks/happy_path_spec.rb
@@ -10,7 +10,7 @@ RSpec::Steps.steps('RancherOnAks: small cluster', type: :system) do
   # Actual password required for re-recording
   let(:test_password) { ENV['PASSWORD'] || 'password' }
   let(:test_tenant) { '0ccfaef4-daa6-4918-8b2a-b9ca95f4a88f' }
-  # let(:test_tls_source) { 'rancher' }
+  let(:test_tls_source) { 'rancher' }
 
   before(:all) do
     driven_by(:rack_test)
@@ -83,12 +83,22 @@ RSpec::Steps.steps('RancherOnAks: small cluster', type: :system) do
     expect(find('.alert-success')).to have_content(t('engines.shirt_size.sizes.using', size: test_shirt_size))
   end
 
-  it 'sets the FQDN and presents the pre-flight checks page' do
+  it 'sets the FQDN and presents the security page' do
     visit(rancher_on_aks.edit_fqdn_path)
     fill_in('fqdn_value', with: test_fqdn)
     click_on(t('actions.next'))
-    expect(page).to have_current_path(pre_flight.checks_path)
+    expect(page).to have_current_path(rancher_on_aks.edit_security_path)
     expect(find('.alert-success')).to have_content(t('flash.using_fqdn', fqdn: test_fqdn))
+  end
+
+  it 'selects a certificate source and presents the pre-flight checks page' do
+    visit(rancher_on_aks.edit_security_path)
+    within 'select#tls_source_source' do
+      find("option[value='#{test_tls_source}']").select_option
+    end
+    click_on(t('actions.next'))
+    expect(page).to have_current_path(pre_flight.checks_path)
+    expect(find('.alert-success')).to have_content(t('flash.tls_source', source: test_tls_source))
   end
 
   it 'runs the pre-flight checks and presents the deploy page' do

--- a/spec/vcr/helm/f8a12295990d8d2896bd6ccfa0e5df63
+++ b/spec/vcr/helm/f8a12295990d8d2896bd6ccfa0e5df63
@@ -1,0 +1,29 @@
+NAME: rancher-stable
+LAST DEPLOYED: Mon Jan 23 18:02:45 2023
+NAMESPACE: cattle-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+Rancher Server has been installed.
+
+NOTE: Rancher may take several minutes to fully initialize. Please standby while Certificates are being issued, Containers are started and the Ingress rule comes up.
+
+Check out our docs at https://rancher.com/docs/
+
+If you provided your own bootstrap password during installation, browse to https://rancher-setup-test.azure.bear454.com to get started.
+
+If this is the first time you installed Rancher, get started by running this command and clicking the URL it generates:
+
+```
+echo https://rancher-setup-test.azure.bear454.com/dashboard/?setup=$(kubectl get secret --namespace cattle-system bootstrap-secret -o go-template='{{.data.bootstrapPassword|base64decode}}')
+```
+
+To get just the bootstrap password on its own, run:
+
+```
+kubectl get secret --namespace cattle-system bootstrap-secret -o go-template='{{.data.bootstrapPassword|base64decode}}{{ "\n" }}'
+```
+
+
+Happy Containering!


### PR DESCRIPTION
~~Depends on `azure-happy-path` branch, as the test is extended to include the security page. Do not merge until after #176 .~~

Adds security page for RancherOnAks with an option for TLS cert, rancher-generated or Let's Encrypt.