### PR TITLE
Steps clean up

### DIFF
--- a/app/models/concerns/deployable.rb
+++ b/app/models/concerns/deployable.rb
@@ -26,7 +26,6 @@ class Deployable
   def rollback()
     Rails.configuration.lasso_deploy_complete = true
     Step.all.order(rank: :desc).each do |step|
-      step.resource&.destroy
       step.destroy if Rails.configuration.lasso_run.present?
     end
   end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,6 +1,8 @@
 class Step < ApplicationRecord
   belongs_to :resource, optional: true
 
+  before_destroy :destroy_resource
+
   def self.deployable?
     Step.count > 0 && Step.where(started_at: nil).count == Step.count
   end
@@ -31,5 +33,13 @@ class Step < ApplicationRecord
 
   def complete?
     !!self.completed_at
+  end
+
+  def cleanup_resource
+    if self.cleanup_resource
+      self.resource&.destroy
+    else
+      self.resource&.delete # removes the record without firing callbacks
+    end
   end
 end

--- a/db/migrate/20230207192140_add_cleanup_resource_to_step.rb
+++ b/db/migrate/20230207192140_add_cleanup_resource_to_step.rb
@@ -1,0 +1,5 @@
+class AddCleanupResourceToStep < ActiveRecord::Migration[7.0]
+  def change
+    add_column :steps, :cleanup_resource, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_13_222137) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_07_192140) do
   create_table "key_values", force: :cascade do |t|
     t.string "key", null: false
     t.text "value"
@@ -47,6 +47,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_13_222137) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "duration", default: 1
+    t.boolean "cleanup_resource", default: true
     t.index ["rank"], name: "index_steps_on_rank", unique: true
   end
 

--- a/engines/rancher_on_aks/app/models/rancher_on_aks/deployment.rb
+++ b/engines/rancher_on_aks/app/models/rancher_on_aks/deployment.rb
@@ -4,7 +4,8 @@ module RancherOnAks
       Step.create!(
         rank: 0,
         duration: 1,
-        action: 'Prep'
+        action: 'Prep',
+        cleanup_resource: false
       )
       Step.create!(
         rank: 1,
@@ -14,22 +15,26 @@ module RancherOnAks
       Step.create!(
         rank: 2,
         duration: 280,
-        action: 'Create an AKS cluster'
+        action: 'Create an AKS cluster',
+        cleanup_resource: false
       )
       Step.create!(
         rank: 3,
         duration: 1,
-        action: 'Fetch the kubeconfig for the AKS cluster'
+        action: 'Fetch the kubeconfig for the AKS cluster',
+        cleanup_resource: false
       )
       Step.create!(
         rank: 4,
         duration: 50,
-        action: 'Deploy the ingress controller'
+        action: 'Deploy the ingress controller',
+        cleanup_resource: false
       )
       Step.create!(
         rank: 5,
         duration: 3,
-        action: 'Find the IP address of the load balancer'
+        action: 'Find the IP address of the load balancer',
+        cleanup_resource: false
       )
       Step.create!(
         rank: 6,
@@ -39,12 +44,14 @@ module RancherOnAks
       Step.create!(
         rank: 7,
         duration: 50,
-        action: 'Deploy the certificate manager'
+        action: 'Deploy the certificate manager',
+        cleanup_resource: false
       )
       Step.create!(
         rank: 8,
         duration: 180,
-        action: 'Deploy Rancher'
+        action: 'Deploy Rancher',
+        cleanup_resource: false
       )
     end
 
@@ -82,7 +89,6 @@ module RancherOnAks
           zones: @zones
         )
         @cluster.ready!
-        nil
       end
       step(3) do
         @cli.update_kubeconfig(
@@ -94,7 +100,6 @@ module RancherOnAks
       step(4) do
         @ingress = Helm::IngressController.create()
         @ingress.ready!
-        nil
       end
       step(5) do
         @public_ip = @ingress.external_ip_address
@@ -110,7 +115,6 @@ module RancherOnAks
       step(7) do
         @cert_manager = Helm::CertManager.create()
         @cert_manager.ready!
-        nil
       end
       step(8) do
         @rancher = Helm::Rancher.create(
@@ -119,7 +123,6 @@ module RancherOnAks
           email_address: @tls_source.email_address
         )
         @rancher.ready!
-        nil
       end
       Rails.configuration.lasso_deploy_complete = true
     end

--- a/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
+++ b/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
@@ -91,7 +91,8 @@ module RancherOnEks
       Step.create!(
         rank: 20,
         duration: 1,
-        action: 'Fetch the kubeconfig for the EKS cluster'
+        action: 'Fetch the kubeconfig for the EKS cluster',
+        cleanup_resource: false
       )
       Step.create!(
         rank: 21,
@@ -106,12 +107,14 @@ module RancherOnEks
       Step.create!(
         rank: 23,
         duration: 50,
-        action: 'Deploy the certificate manager'
+        action: 'Deploy the certificate manager',
+        cleanup_resource: false
       )
       Step.create!(
         rank: 24,
         duration: 18,
-        action: 'Deploy Rancher'
+        action: 'Deploy Rancher',
+        cleanup_resource: false
       )
     end
 
@@ -256,7 +259,6 @@ module RancherOnEks
         @ingress = Helm::IngressController.create()
         @type = @ingress.type
         @ingress.wait_until(:deployed)
-        nil
       end
       step(22) do
         @ingress ||= Step.find_by_rank(21).resource
@@ -272,7 +274,6 @@ module RancherOnEks
         @cert_manager = Helm::CertManager.create()
         @type = @cert_manager.type
         @cert_manager.wait_until(:deployed)
-        nil
       end
       step(24) do
         @fqdn_record ||= Step.find_by_rank(22).resource
@@ -290,7 +291,6 @@ module RancherOnEks
         )
         @type = @rancher.type
         @rancher.wait_until(:deployed)
-        nil
       end
       Rails.configuration.lasso_deploy_complete = true
       # in case Rancher create command gets failed status


### PR DESCRIPTION
I added a boolean attribute to the step, defaulting to _true_, indicating if the attached resource requires cleanup.

I then updated the deployments to indicate explicitly which steps _don't_ require cleanup. As a result of having the cleanup logic, we can go ahead and attach all the resources to the steps (getting rid of a bunch of those pesky `nil` lines).