### PR TITLE
Move loading of checks to initialization

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,6 @@ require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+# Load Pre-Flight Checks from configured workflow
+Rails.configuration.workflow.constantize.load_pre_flight_checks!

--- a/engines/pre_flight/app/controllers/pre_flight/checks_controller.rb
+++ b/engines/pre_flight/app/controllers/pre_flight/checks_controller.rb
@@ -1,7 +1,6 @@
 module PreFlight
   class ChecksController < PreFlight::ApplicationController
     def index
-      workflow.load_pre_flight_checks!
       @checks = PreFlight::Check.all
 
       @all_complete = PreFlight::Check.all_complete?


### PR DESCRIPTION
Pre-flight checks were being populated when you hit the page; but this gave a false positive on authorization, as all (0) checks were passing, before that.

In order to ensure the auth works properly with pre-flight checks, load them at the end of initialization.