### PR TITLE
Preflight check count

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,10 +9,6 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.load(session[:authorized_at])
   end
 
-  def workflow
-    Rails.configuration.workflow.constantize
-  end
-
   def authorize
     unless @current_user.is_authorized?
       flash[:danger] = t('flash.login_required')

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,0 +1,7 @@
+# Singleton class shortcut to the configured worflow engine
+class Workflow
+  def self.method_missing(m, *args, &block)
+    workflow = Rails.configuration.workflow.constantize
+    workflow.send(m, *args, &block)
+  end
+end

--- a/engines/pre_flight/app/controllers/pre_flight/checks_controller.rb
+++ b/engines/pre_flight/app/controllers/pre_flight/checks_controller.rb
@@ -1,7 +1,7 @@
 module PreFlight
   class ChecksController < PreFlight::ApplicationController
     def index
-      workflow.load_pre_flight_checks!
+      Workflow.load_pre_flight_checks!
       @checks = PreFlight::Check.all
 
       @all_complete = PreFlight::Check.all_complete?

--- a/engines/pre_flight/app/models/pre_flight/check.rb
+++ b/engines/pre_flight/app/models/pre_flight/check.rb
@@ -7,7 +7,7 @@ module PreFlight
     scope :all_failed, -> { where.not(passed: true, job_completed_at: nil) }
 
     def self.all_passed?
-      where(passed: true).count == all.count
+      where(passed: true).count == Workflow.preflight_check_count
     end
 
     def self.all_complete?

--- a/engines/rancher_on_aks/lib/rancher_on_aks.rb
+++ b/engines/rancher_on_aks/lib/rancher_on_aks.rb
@@ -22,4 +22,8 @@ module RancherOnAks
       job: 'Azure::PublicIpAddressQuotaCheckJob'
     )
   end
+
+  def self.preflight_check_count
+    2
+  end
 end

--- a/engines/rancher_on_eks/lib/rancher_on_eks.rb
+++ b/engines/rancher_on_eks/lib/rancher_on_eks.rb
@@ -18,4 +18,8 @@ module RancherOnEks
       job: 'AWS::VpcQuotaCheckJob'
     )
   end
+
+  def self.preflight_check_count
+    1
+  end
 end


### PR DESCRIPTION
Pre-flight checks were being populated when you hit the page; but this gave a false positive on authorization, as all (0) checks were passing, before that.

In order to ensure the auth works properly with pre-flight checks, check against an expected count provided by the workflow.
