### PR TITLE
Handle kubeconfig as a resource for easier cleanup

### DIFF
--- a/engines/aws/app/models/aws/cluster.rb
+++ b/engines/aws/app/models/aws/cluster.rb
@@ -21,6 +21,10 @@ module AWS
       self.wait_until(:not_found)
     end
 
+    def to_s
+      self.id
+    end
+
     def describe_resource
       @cli.describe_cluster(self.id)
     end

--- a/engines/aws/app/models/aws/kubeconfig.rb
+++ b/engines/aws/app/models/aws/kubeconfig.rb
@@ -1,0 +1,17 @@
+module AWS
+  class Kubeconfig < AWSResource
+    attr_accessor :cluster
+
+    def create_command
+      self.creation_attributes = {
+        cluster: @cluster
+      }
+      @cli.update_kube_config(@cluster)
+      self.id = 'kubeconfig'
+    end
+
+    def destroy_command
+      @cli.update_kube_config(@cluster) if Rails.configuration.record_commands
+    end
+  end
+end

--- a/engines/azure/app/models/azure/kubeconfig.rb
+++ b/engines/azure/app/models/azure/kubeconfig.rb
@@ -1,0 +1,24 @@
+module Azure
+  class Kubeconfig < AzureResource
+    attr_accessor :cluster, :resource_group
+
+    def create_command()
+      self.creation_attributes = {
+        cluster: @cluster,
+        resource_group: @resource_group
+      }
+      @cli.update_kubeconfig(
+        cluster: @cluster,
+        resource_group: @resource_group
+      )
+      self.id = 'kubeconfig'
+    end
+
+    def destroy_command()
+      @cli.update_kubeconfig(
+        cluster: @cluster,
+        resource_group: @resource_group
+      ) if Rails.configuration.record_commands
+    end
+  end
+end

--- a/engines/rancher_on_aks/app/models/rancher_on_aks/deployment.rb
+++ b/engines/rancher_on_aks/app/models/rancher_on_aks/deployment.rb
@@ -53,6 +53,12 @@ module RancherOnAks
         action: 'Deploy Rancher',
         cleanup_resource: false
       )
+      Step.create!(
+        rank: 9,
+        duration: 1,
+        action: 'Store the kubeconfig',
+        cleanup_resource: true
+      )
     end
 
     def deploy()
@@ -91,7 +97,7 @@ module RancherOnAks
         @cluster.ready!
       end
       step(3) do
-        @cli.update_kubeconfig(
+        @kubeconfig = Azure::Kubeconfig.create(
           cluster: @cluster,
           resource_group: @resource_group
         )
@@ -123,6 +129,9 @@ module RancherOnAks
           email_address: @tls_source.email_address
         )
         @rancher.ready!
+      end
+      step(9) do
+        @kubeconfig # Attach at the end for easier cleanup
       end
     end
   end


### PR DESCRIPTION
When we cleanup, the method for exporting kubeconfig can be included.