### PR TITLE
Limit flash error message sizes to not overflow cookie session

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -14,7 +14,7 @@ class LoginController < ApplicationController
     session[:authorized_at] = user.authorize
     redirect_path = helpers.next_step_path(login_path)
     unless user.is_authorized?
-      flash[:danger] = user.errors.full_messages.join("\n")
+      flash[:danger] = user.errors.full_messages.join("\n").truncate(1000)
       redirect_path = root_path
     end
     redirect_to(redirect_path)

--- a/engines/aws/app/controllers/aws/permissions_controller.rb
+++ b/engines/aws/app/controllers/aws/permissions_controller.rb
@@ -12,7 +12,7 @@ module AWS
     rescue AWS::MissingInstanceProfile
       flash[:danger] = t('flash.missing_instance_profile')
     rescue StandardError => error
-      flash[:danger] = t('error', message: error.message)
+      flash[:danger] = t('error', message: error.message).truncate(1000)
     end
   end
 end

--- a/engines/azure/app/controllers/azure/logins_controller.rb
+++ b/engines/azure/app/controllers/azure/logins_controller.rb
@@ -10,7 +10,7 @@ module Azure
         flash[:success] = t('engines.azure.login.success', service_principal: @credential.app_id)
         redirect_path = helpers.next_step_path(azure.edit_login_path)
       else
-        flash[:danger] = t('engines.azure.login.failure', message: @credential.errors.full_messages)
+        flash[:danger] = t('engines.azure.login.failure', message: @credential.errors.full_messages).truncate(1000)
         redirect_path = azure.edit_login_path
       end
       redirect_to(redirect_path)

--- a/engines/rancher_on_aks/app/controllers/rancher_on_aks/steps_controller.rb
+++ b/engines/rancher_on_aks/app/controllers/rancher_on_aks/steps_controller.rb
@@ -8,7 +8,7 @@ module RancherOnAks
       @resources = Resource.where.associated(:steps)
 
       if Rails.configuration.lasso_error.present?
-        flash[:danger] = Rails.configuration.lasso_error
+        flash[:danger] = Rails.configuration.lasso_error.truncate(1000)
         @complete = true
       end
       redirect_to(rancher_on_aks.wrapup_path) and return if @complete

--- a/engines/rancher_on_eks/app/controllers/rancher_on_eks/steps_controller.rb
+++ b/engines/rancher_on_eks/app/controllers/rancher_on_eks/steps_controller.rb
@@ -8,7 +8,7 @@ module RancherOnEks
       @resources = Resource.where.associated(:steps)
 
       if Rails.configuration.lasso_error.present?
-        flash[:danger] = Rails.configuration.lasso_error
+        flash[:danger] = Rails.configuration.lasso_error.truncate(1000)
         @complete = true
       end
       redirect_to(rancher_on_eks.wrapup_path) and return if @complete


### PR DESCRIPTION
Flash messages are stored in the session; in Lasso's case the session is stored in a cookie, and therefore limited to a maximum of 4K. If an error message is excessively long, it can cause a cookie overflow error, blow the session, and force Rails to throw a 500 Application Error, which loses the original error posted to the flash. Better to preserve a smaller portion of the error (a 1000 characters should be enough) than lose it altogether.